### PR TITLE
[#614][feat] Add TOC and summary tables to partial-consensus output format

### DIFF
--- a/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
+++ b/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
@@ -156,6 +156,22 @@ Use this format for ALL outputs (consensus or partial consensus):
 ```markdown
 # Implementation Plan: {{FEATURE_NAME}}
 
+## Table of Contents
+
+- [Agent Perspectives Summary](#agent-perspectives-summary)
+- [Consensus Assessment](#consensus-assessment)
+- [Goal](#goal)
+- [Codebase Analysis](#codebase-analysis)
+- [Implementation Steps](#implementation-steps)
+- [Success Criteria](#success-criteria)
+- [Risks and Mitigations](#risks-and-mitigations)
+- [Overall Recommendation](#overall-recommendation)
+- [Disagreement 1: \[Topic\]](#disagreement-1-topic) *(if applicable)*
+- [Selection History](#selection-history)
+- [Refine History](#refine-history)
+
+---
+
 ## Agent Perspectives Summary
 
 | Agent | Core Position | Key Insight |
@@ -265,6 +281,14 @@ Use this format for ALL outputs (consensus or partial consensus):
 | **Code Reducer** | [Impact] | [LOC difference between approaches] |
 
 ### Resolution Options
+
+| Option | Name | Source | Summary |
+|--------|------|--------|---------|
+| [1A](#option-1a-name-conservative) | [Name] | [Source] | [1-sentence summary] |
+| [1B](#option-1b-name-aggressive) | [Name] | [Source] | [1-sentence summary] |
+| [1C](#option-1c-name-balanced) | [Name] | [Source] | [1-sentence summary] |
+
+---
 
 #### Option 1A: [Name] (Conservative)
 

--- a/tests/lint/test-partial-review-prompt.sh
+++ b/tests/lint/test-partial-review-prompt.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Lint test for partial-review-prompt.md structure
+#
+
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+PROMPT_FILE="$PROJECT_ROOT/.claude-plugin/skills/partial-consensus/partial-review-prompt.md"
+
+echo "Testing partial-review-prompt.md structure..."
+
+# Test 1: TOC section exists
+if ! grep -q "## Table of Contents" "$PROMPT_FILE"; then
+    echo "FAIL: Missing '## Table of Contents' section"
+    exit 1
+fi
+echo "PASS: TOC section exists"
+
+# Test 2: TOC contains core anchors
+REQUIRED_ANCHORS=(
+    "#agent-perspectives-summary"
+    "#consensus-assessment"
+    "#goal"
+    "#implementation-steps"
+)
+
+for anchor in "${REQUIRED_ANCHORS[@]}"; do
+    if ! grep -q "$anchor" "$PROMPT_FILE"; then
+        echo "FAIL: Missing required TOC anchor: $anchor"
+        exit 1
+    fi
+done
+echo "PASS: Required TOC anchors present"
+
+# Test 3: Resolution Options Summary table header exists
+if ! grep -qE "\| Option \| Name \| Source \| Summary \|" "$PROMPT_FILE"; then
+    echo "FAIL: Missing Resolution Options Summary table"
+    exit 1
+fi
+echo "PASS: Resolution Options Summary table present"
+
+echo "All partial-review-prompt.md structure tests passed!"


### PR DESCRIPTION
## Summary
- Add Table of Contents section with hyperlinked anchors at document beginning for better navigation
- Add Resolution Options Summary table after `### Resolution Options` header for quick option scanning
- Add lint test to validate TOC and summary table structure in partial-review-prompt.md

## Test plan
- [x] TOC section appears after H1 title in output format template
- [x] TOC contains hyperlinked entries to all major sections
- [x] Resolution Options Summary table appears in template
- [x] Lint test passes validating structure (`tests/lint/test-partial-review-prompt.sh`)
- [x] Full lint test suite passes (`tests/test-all.sh lint`)
- [x] All shell tests pass (`make test-fast`)

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)