### PR TITLE
[#616][refactor] Replace Overall Recommendation with Disagreement Summary

### DIFF
--- a/.claude-plugin/skills/partial-consensus/SKILL.md
+++ b/.claude-plugin/skills/partial-consensus/SKILL.md
@@ -67,7 +67,7 @@ leveraging LLM recency bias to prioritize the current request.
 | Goal / Codebase Analysis | Problem statement and file changes |
 | Implementation Steps | Agreed changes with code drafts |
 | Disagreement N (if any) | Per-disagreement options with A/B/C choices |
-| Overall Recommendation | Suggested combination and rationale |
+| Disagreement Summary | Summary table and suggested combination |
 | Validation (resolve mode) | Selection history and compatibility check |
 
 *See `partial-review-prompt.md` for complete output format specification.*

--- a/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
+++ b/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
@@ -52,7 +52,7 @@ If the combined report contains a `## Part 7: Selection & Refine History` sectio
   - Merge the selected approaches coherently into Implementation Steps
   - Use standard format: Goal, Codebase Analysis, Implementation Steps
   - Include code drafts from the selected options
-  - **Skip Overall Recommendation section** (no Disagreement Summary, no Suggested Combination - already resolved)
+  - **Skip Disagreement Summary section** (already resolved)
   - **Skip Consensus Assessment section** (consensus already determined in previous iteration)
   - Include Validation section at the end (see output format below)
 - Skip the "if consensus IS possible / IS NOT possible" logic below
@@ -165,7 +165,7 @@ Use this format for ALL outputs (consensus or partial consensus):
 - [Implementation Steps](#implementation-steps)
 - [Success Criteria](#success-criteria)
 - [Risks and Mitigations](#risks-and-mitigations)
-- [Overall Recommendation](#overall-recommendation)
+- [Disagreement Summary](#disagreement-summary)
 - [Disagreement 1: \[Topic\]](#disagreement-1-topic) *(if applicable)*
 - [Selection History](#selection-history)
 - [Refine History](#refine-history)
@@ -249,9 +249,7 @@ Use this format for ALL outputs (consensus or partial consensus):
 |------|------------|--------|------------|
 | [Risk] | H/M/L | H/M/L | [Strategy] |
 
-## Overall Recommendation
-
-### Disagreement Summary
+## Disagreement Summary
 
 | # | Topic | Options | AI Recommendation |
 |---|-------|---------|-------------------|


### PR DESCRIPTION
## Summary

- Remove redundant `## Overall Recommendation` wrapper heading from partial-review-prompt.md
- Promote `### Disagreement Summary` to H2 level (`## Disagreement Summary`)
- Update line 55 resolve mode reference to new section name
- Update SKILL.md output format table reference

Closes #616

## Test plan

- [x] Verify `## Overall Recommendation` heading no longer exists in partial-review-prompt.md
- [x] Verify `## Disagreement Summary` exists at H2 level
- [x] Verify `### Suggested Combination` remains as H3 under Disagreement Summary
- [x] Verify no stale references to "Overall Recommendation" in either file
- [x] Run `make test-fast` - 46/46 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
