### PR TITLE
[feat][#612] Add mega-planner and partial-consensus support to hooks

### DIFF
--- a/.claude-plugin/lib/permission/determine.py
+++ b/.claude-plugin/lib/permission/determine.py
@@ -514,6 +514,8 @@ def _detect_workflow(session: str) -> str:
             workflow_type = state.get('workflow', '')
             if workflow_type == 'ultra-planner':
                 return 'plan'
+            elif workflow_type == 'mega-planner':
+                return 'plan'
             elif workflow_type == 'issue-to-impl':
                 return 'impl'
             elif workflow_type == 'plan-to-issue':
@@ -576,12 +578,13 @@ def _check_workflow_auto_allow(session: str, tool: str, target: str) -> Optional
     """
     workflow = _get_workflow_type(session)
 
-    # Auto-allow issue creation and editing for ultra-planner workflow
-    if workflow == 'ultra-planner' and tool == 'Bash':
+    # Auto-allow issue creation and editing for ultra-planner and mega-planner workflows
+    if workflow in ('ultra-planner', 'mega-planner') and tool == 'Bash':
         issue_creation_patterns = [
             r'^gh issue create\s+--title\s+.*--body\s+.*',  # gh issue create with title and body
             r'^gh issue edit\s+\d+\s+--title\s+.*',         # gh issue edit with title
             r'^gh issue edit\s+\d+\s+--body\s+.*',          # gh issue edit with body
+            r'^gh issue edit\s+\d+\s+--body-file\s+.*',     # gh issue edit with body-file
         ]
         for pattern in issue_creation_patterns:
             if re.match(pattern, target):

--- a/.claude-plugin/lib/permission/rules.py
+++ b/.claude-plugin/lib/permission/rules.py
@@ -18,6 +18,7 @@ PERMISSION_RULES = {
         ('Skill', r'^commit-msg'),
         ('Skill', r'^review-standard'),
         ('Skill', r'^external-consensus'),
+        ('Skill', r'^partial-consensus'),
         ('Skill', r'^milestone'),
         ('Skill', r'^code-review'),
         ('Skill', r'^pull-request'),
@@ -28,6 +29,7 @@ PERMISSION_RULES = {
         ('Skill', r'^agentize:commit-msg'),
         ('Skill', r'^agentize:review-standard'),
         ('Skill', r'^agentize:external-consensus'),
+        ('Skill', r'^agentize:partial-consensus'),
         ('Skill', r'^agentize:milestone'),
         ('Skill', r'^agentize:code-review'),
         ('Skill', r'^agentize:pull-request'),
@@ -103,6 +105,9 @@ PERMISSION_RULES = {
 
         # Bash - External consensus script
         ('Bash', r'^\.claude/skills/external-consensus/scripts/external-consensus\.sh'),
+
+        # Bash - Partial consensus script
+        ('Bash', r'^\.claude-plugin/skills/partial-consensus/scripts/partial-consensus\.sh'),
 
         # Bash - Git write operations (more aggressive)
         ('Bash', r'^git add'),

--- a/.claude-plugin/lib/workflow.py
+++ b/.claude-plugin/lib/workflow.py
@@ -5,7 +5,8 @@ prompts for all supported handsoff workflows. Adding a new workflow requires
 editing only this file.
 
 Supported workflows:
-- /ultra-planner: Multi-agent debate-based planning
+- /ultra-planner: Multi-agent debate-based planning (3-agent)
+- /mega-planner: Multi-agent debate-based planning (5-agent, shares ultra-planner prompt)
 - /issue-to-impl: Complete development cycle from issue to PR
 - /plan-to-issue: Create GitHub [plan] issues from user-provided plans
 - /setup-viewboard: GitHub Projects v2 board setup
@@ -33,6 +34,7 @@ from lib.session_utils import get_agentize_home
 # ============================================================
 
 ULTRA_PLANNER = 'ultra-planner'
+MEGA_PLANNER = 'mega-planner'
 ISSUE_TO_IMPL = 'issue-to-impl'
 PLAN_TO_ISSUE = 'plan-to-issue'
 SETUP_VIEWBOARD = 'setup-viewboard'
@@ -44,6 +46,7 @@ SYNC_MASTER = 'sync-master'
 
 WORKFLOW_COMMANDS = {
     '/ultra-planner': ULTRA_PLANNER,
+    '/mega-planner': MEGA_PLANNER,
     '/issue-to-impl': ISSUE_TO_IMPL,
     '/plan-to-issue': PLAN_TO_ISSUE,
     '/setup-viewboard': SETUP_VIEWBOARD,
@@ -54,7 +57,7 @@ WORKFLOW_COMMANDS = {
 # Supported workflow types for template loading
 # ============================================================
 
-_SUPPORTED_WORKFLOWS = {ULTRA_PLANNER, ISSUE_TO_IMPL, PLAN_TO_ISSUE, SETUP_VIEWBOARD, SYNC_MASTER}
+_SUPPORTED_WORKFLOWS = {ULTRA_PLANNER, MEGA_PLANNER, ISSUE_TO_IMPL, PLAN_TO_ISSUE, SETUP_VIEWBOARD, SYNC_MASTER}
 
 
 def _load_prompt_template(workflow_type: str) -> str:

--- a/.claude-plugin/prompts/mega-planner.txt
+++ b/.claude-plugin/prompts/mega-planner.txt
@@ -1,0 +1,1 @@
+ultra-planner.txt

--- a/tests/cli/test-workflow-module.sh
+++ b/tests/cli/test-workflow-module.sh
@@ -32,6 +32,18 @@ test_info "Test 2: detect_workflow('/ultra-planner --refine 42') → ultra-plann
 RESULT=$(run_workflow_python "from lib.workflow import detect_workflow; print(detect_workflow('/ultra-planner --refine 42'))")
 [ "$RESULT" = "ultra-planner" ] || test_fail "Expected 'ultra-planner', got '$RESULT'"
 
+test_info "Test 2a: detect_workflow('/mega-planner') → mega-planner"
+RESULT=$(run_workflow_python "from lib.workflow import detect_workflow; print(detect_workflow('/mega-planner'))")
+[ "$RESULT" = "mega-planner" ] || test_fail "Expected 'mega-planner', got '$RESULT'"
+
+test_info "Test 2b: detect_workflow('/mega-planner --refine 42') → mega-planner"
+RESULT=$(run_workflow_python "from lib.workflow import detect_workflow; print(detect_workflow('/mega-planner --refine 42'))")
+[ "$RESULT" = "mega-planner" ] || test_fail "Expected 'mega-planner', got '$RESULT'"
+
+test_info "Test 2c: detect_workflow('/mega-planner --from-issue 123') → mega-planner"
+RESULT=$(run_workflow_python "from lib.workflow import detect_workflow; print(detect_workflow('/mega-planner --from-issue 123'))")
+[ "$RESULT" = "mega-planner" ] || test_fail "Expected 'mega-planner', got '$RESULT'"
+
 test_info "Test 3: detect_workflow('/issue-to-impl 42') → issue-to-impl"
 RESULT=$(run_workflow_python "from lib.workflow import detect_workflow; print(detect_workflow('/issue-to-impl 42'))")
 [ "$RESULT" = "issue-to-impl" ] || test_fail "Expected 'issue-to-impl', got '$RESULT'"
@@ -108,6 +120,10 @@ test_info "Test 16: has_continuation_prompt('ultra-planner') → True"
 RESULT=$(run_workflow_python "from lib.workflow import has_continuation_prompt; print(has_continuation_prompt('ultra-planner'))")
 [ "$RESULT" = "True" ] || test_fail "Expected 'True', got '$RESULT'"
 
+test_info "Test 16a: has_continuation_prompt('mega-planner') → True"
+RESULT=$(run_workflow_python "from lib.workflow import has_continuation_prompt; print(has_continuation_prompt('mega-planner'))")
+[ "$RESULT" = "True" ] || test_fail "Expected 'True', got '$RESULT'"
+
 test_info "Test 17: has_continuation_prompt('issue-to-impl') → True"
 RESULT=$(run_workflow_python "from lib.workflow import has_continuation_prompt; print(has_continuation_prompt('issue-to-impl'))")
 [ "$RESULT" = "True" ] || test_fail "Expected 'True', got '$RESULT'"
@@ -172,6 +188,14 @@ print('VIEWBOARD_OK' if 'Projects v2 board' in prompt else 'VIEWBOARD_MISSING')
 ")
 [ "$RESULT" = "VIEWBOARD_OK" ] || test_fail "Expected 'Projects v2 board' in setup-viewboard prompt, got '$RESULT'"
 
+test_info "Test 26a: get_continuation_prompt() for mega-planner returns non-empty"
+RESULT=$(run_workflow_python "
+from lib.workflow import get_continuation_prompt
+prompt = get_continuation_prompt('mega-planner', 'test-session', '/tmp/test.json', 1, 10)
+print('MEGA_OK' if len(prompt) > 0 else 'MEGA_EMPTY')
+")
+[ "$RESULT" = "MEGA_OK" ] || test_fail "Expected non-empty mega-planner prompt, got '$RESULT'"
+
 test_info "Test 27: get_continuation_prompt() for unknown workflow returns empty string"
 RESULT=$(run_workflow_python "
 from lib.workflow import get_continuation_prompt
@@ -216,6 +240,10 @@ print('NO_PLAN_OK' if 'milestone' in prompt.lower() and 'Plan file:' not in prom
 test_info "Test 28: ULTRA_PLANNER constant equals 'ultra-planner'"
 RESULT=$(run_workflow_python "from lib.workflow import ULTRA_PLANNER; print(ULTRA_PLANNER)")
 [ "$RESULT" = "ultra-planner" ] || test_fail "Expected 'ultra-planner', got '$RESULT'"
+
+test_info "Test 28a: MEGA_PLANNER constant equals 'mega-planner'"
+RESULT=$(run_workflow_python "from lib.workflow import MEGA_PLANNER; print(MEGA_PLANNER)")
+[ "$RESULT" = "mega-planner" ] || test_fail "Expected 'mega-planner', got '$RESULT'"
 
 test_info "Test 29: ISSUE_TO_IMPL constant equals 'issue-to-impl'"
 RESULT=$(run_workflow_python "from lib.workflow import ISSUE_TO_IMPL; print(ISSUE_TO_IMPL)")


### PR DESCRIPTION
## Summary

Added support for mega-planner workflow and partial-consensus skill in the handsoff mode hooks system. This enables 5-agent debate workflows to operate in handsoff mode with proper permission handling and continuation prompts.

## Changes

- Modified `.claude-plugin/lib/workflow.py:33-57` to add MEGA_PLANNER constant, command mapping, and supported workflows entry
- Updated `.claude-plugin/lib/permission/rules.py:18-110` to add partial-consensus skill allow rules and bash script permission
- Updated `.claude-plugin/lib/permission/determine.py:514-587` to add mega-planner workflow detection and auto-allow patterns for issue creation/editing including `--body-file` support
- Created `.claude-plugin/prompts/mega-planner.txt` as symlink to `ultra-planner.txt` (shared continuation prompt)
- Added `tests/cli/test-workflow-module.sh:32-241` with tests for mega-planner workflow detection, MEGA_PLANNER constant, and continuation prompts

## Testing

- Added 7 new tests in `tests/cli/test-workflow-module.sh`:
  - Test 2a-2c: `detect_workflow()` for mega-planner command variants
  - Test 16a: `has_continuation_prompt('mega-planner')` returns True
  - Test 26a: `get_continuation_prompt()` for mega-planner returns non-empty
  - Test 28a: `MEGA_PLANNER` constant equals 'mega-planner'
- All 44 workflow module tests pass
- Full test suite verified (45/46 tests pass; 1 pre-existing failure unrelated to this PR)

## Related Issue

Closes #612
