### PR TITLE
[#620][fix] Fix terminology inconsistencies in partial-review-prompt.md

### DIFF
--- a/.claude-plugin/skills/partial-consensus/SKILL.md
+++ b/.claude-plugin/skills/partial-consensus/SKILL.md
@@ -63,7 +63,7 @@ leveraging LLM recency bias to prioritize the current request.
 | Section | Description |
 |---------|-------------|
 | Agent Perspectives Summary | 5-agent position table |
-| Consensus Assessment | 3-condition evaluation with PASS/FAIL verdict |
+| Consensus Status | 3-condition evaluation with CONSENSUS/DISAGREEMENT verdict |
 | Goal / Codebase Analysis | Problem statement and file changes |
 | Implementation Steps | Agreed changes with code drafts |
 | Disagreement N (if any) | Per-disagreement options with A/B/C choices |

--- a/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
+++ b/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
@@ -53,7 +53,7 @@ If the combined report contains a `## Part 7: Selection & Refine History` sectio
   - Use standard format: Goal, Codebase Analysis, Implementation Steps
   - Include code drafts from the selected options
   - **Skip Disagreement Summary section** (already resolved)
-  - **Skip Consensus Assessment section** (consensus already determined in previous iteration)
+  - **Skip Consensus Status section** (consensus already determined in previous iteration)
   - Include Validation section at the end (see output format below)
 - Skip the "if consensus IS possible / IS NOT possible" logic below
 
@@ -87,16 +87,8 @@ Each option MUST specify its source (which agent(s) it derives from).
 
 ### Rule 1: Cite Both Sides
 
-When proposals disagree, document both positions before deciding:
-
-```
-### Disagreement: [Topic]
-
-**Bold claims**: [Quote from bold proposal]
-**Paranoia claims**: [Quote from paranoia proposal]
-**Critique says**: [What critique agent found]
-**Resolution**: [Which side is adopted and why, with evidence]
-```
+When proposals disagree, document both positions in the **Agent Perspectives** table
+under each Disagreement section (see output format template below for table structure).
 
 ### Rule 2: No Automatic Dropping
 
@@ -151,7 +143,7 @@ When history exists, produce a single unified plan applying the latest selection
 
 ### Unified Output Format
 
-Use this format for ALL outputs (consensus or partial consensus):
+Use this format for ALL outputs (consensus or disagreement):
 
 ```markdown
 # Implementation Plan: {{FEATURE_NAME}}

--- a/tests/lint/test-partial-review-prompt.sh
+++ b/tests/lint/test-partial-review-prompt.sh
@@ -21,7 +21,7 @@ echo "PASS: TOC section exists"
 # Test 2: TOC contains core anchors
 REQUIRED_ANCHORS=(
     "#agent-perspectives-summary"
-    "#consensus-assessment"
+    "#consensus-status"
     "#goal"
     "#implementation-steps"
 )


### PR DESCRIPTION
## Summary

- Replace "Consensus Assessment" with "Consensus Status" to match the template section naming
- Simplify Rule 1 citation format to reference the existing Agent Perspectives table (removes duplicate table definition)
- Fix wording from "consensus or partial consensus" to "consensus or disagreement" to align with Consensus Definition section
- Update lint test anchor expectation from `#consensus-assessment` to `#consensus-status`

## Test plan

- [x] `bash tests/lint/test-partial-review-prompt.sh` passes
- [x] No remaining occurrences of "Consensus Assessment" in partial-consensus skill files
- [x] All terminology now consistent between rules and template sections

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)