### PR TITLE
[#622][feat] Add explicit HTML anchors to partial-review-prompt.md

### DIFF
--- a/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
+++ b/.claude-plugin/skills/partial-consensus/partial-review-prompt.md
@@ -164,6 +164,7 @@ Use this format for ALL outputs (consensus or disagreement):
 
 ---
 
+<a id="agent-perspectives-summary"></a>
 ## Agent Perspectives Summary
 
 | Agent | Core Position | Key Insight |
@@ -174,10 +175,12 @@ Use this format for ALL outputs (consensus or disagreement):
 | **Proposal Reducer** | [Simplification direction] | [What complexity was removed] |
 | **Code Reducer** | [Code impact assessment] | [LOC delta summary] |
 
+<a id="consensus-status"></a>
 ## Consensus Status
 
 [One paragraph explaining the consensus determination, citing key evidence from agents' positions]
 
+<a id="goal"></a>
 ## Goal
 
 [Problem statement synthesized from proposals]
@@ -185,6 +188,7 @@ Use this format for ALL outputs (consensus or disagreement):
 **Out of scope:**
 - [What we're not doing]
 
+<a id="codebase-analysis"></a>
 ## Codebase Analysis
 
 **File changes:**
@@ -193,6 +197,7 @@ Use this format for ALL outputs (consensus or disagreement):
 |------|-------|---------|
 | `path/to/file` | major/medium/minor | Description |
 
+<a id="implementation-steps"></a>
 ## Implementation Steps
 
 > **Note**: Include only consensus steps here—steps that ALL agents agree on. Disputed approaches belong in their respective `## Disagreement N` sections below.
@@ -225,16 +230,19 @@ Use this format for ALL outputs (consensus or disagreement):
 
 </details>
 
+<a id="success-criteria"></a>
 ## Success Criteria
 
 - [ ] [Criterion 1]
 
+<a id="risks-and-mitigations"></a>
 ## Risks and Mitigations
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
 | [Risk] | H/M/L | H/M/L | [Strategy] |
 
+<a id="disagreement-summary"></a>
 ## Disagreement Summary
 
 | # | Topic | Options | AI Recommendation |
@@ -252,6 +260,7 @@ Use this format for ALL outputs (consensus or disagreement):
 
 ---
 
+<a id="disagreement-1-topic"></a>
 ## Disagreement 1: [Topic Name]
 
 ### Agent Perspectives
@@ -413,6 +422,7 @@ Use this format for ALL outputs (consensus or disagreement):
 
 ---
 
+<a id="selection-history"></a>
 ## Selection History
 
 **Row Granularity**: Each row represents ONE disagreement point, not one resolve command.
@@ -422,6 +432,7 @@ Use this format for ALL outputs (consensus or disagreement):
 | [Previous rows from history file] |
 | 2026-01-22 19:30 | 1: Agent Naming | 1A (Paranoia): suffix; 1B (Bold): prefix | 1B (Bold) | Prefix matches existing |
 
+<a id="refine-history"></a>
 ## Refine History
 
 **Row Granularity**: Each row represents one `--refine` operation.

--- a/tests/lint/test-partial-review-prompt.sh
+++ b/tests/lint/test-partial-review-prompt.sh
@@ -34,7 +34,31 @@ for anchor in "${REQUIRED_ANCHORS[@]}"; do
 done
 echo "PASS: Required TOC anchors present"
 
-# Test 3: Resolution Options Summary table header exists
+# Test 3: Explicit HTML anchors exist for TOC links
+# GitHub Issue bodies do NOT auto-generate heading IDs, so explicit anchors are required
+REQUIRED_HTML_ANCHORS=(
+    '<a id="agent-perspectives-summary"></a>'
+    '<a id="consensus-status"></a>'
+    '<a id="goal"></a>'
+    '<a id="codebase-analysis"></a>'
+    '<a id="implementation-steps"></a>'
+    '<a id="success-criteria"></a>'
+    '<a id="risks-and-mitigations"></a>'
+    '<a id="disagreement-summary"></a>'
+    '<a id="disagreement-1-topic"></a>'
+    '<a id="selection-history"></a>'
+    '<a id="refine-history"></a>'
+)
+
+for anchor in "${REQUIRED_HTML_ANCHORS[@]}"; do
+    if ! grep -qF "$anchor" "$PROMPT_FILE"; then
+        echo "FAIL: Missing explicit HTML anchor: $anchor"
+        exit 1
+    fi
+done
+echo "PASS: Explicit HTML anchors present"
+
+# Test 4: Resolution Options Summary table header exists
 if ! grep -qE "\| Option \| Name \| Source \| Summary \|" "$PROMPT_FILE"; then
     echo "FAIL: Missing Resolution Options Summary table"
     exit 1


### PR DESCRIPTION
## Summary

- Add 11 explicit `<a id="..."></a>` HTML anchor tags to `partial-review-prompt.md` template
- Add lint test to enforce explicit anchor presence
- Verified empirically that GitHub Issue bodies do NOT auto-generate heading IDs

## Background

GitHub's markdown rendering auto-generates heading IDs only for file views (README.md, etc.), NOT for Issue/PR bodies. This was confirmed by:
1. Creating test issue #10 with TOC links
2. Inspecting rendered HTML via `gh api` with `Accept: application/vnd.github.full+json`
3. Observing `<h2>` elements have NO `id` attribute

## Test plan

- [x] `tests/lint/test-partial-review-prompt.sh` passes
- [x] `make test-fast` shell tests pass (46/46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)